### PR TITLE
refactor: promisify buildApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Hacker Suite Applications
+# Hacker Suite: Applications
+
+Applications system for Hackathons.
 
 <p align="center">
   <a href="https://github.com/unicsmcr/hs_application/actions?query=workflow%3ATests" alt="Build Status">

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,3 @@
-import { Express } from 'express';
 import { App } from './app';
 import { logger } from './util';
 
@@ -6,13 +5,14 @@ import { logger } from './util';
  * Start Express server.
  */
 
-new App().buildApp((app: Express, err?: Error) => {
-	if (err) {
-		logger.error('Could not start server!');
-	} else {
+new App().buildApp()
+	.then(app => {
 		app.listen(app.get('port'), () => {
-			logger.info('App is running at http://localhost:%d in %s mode', app.get('port'), app.get('env'));
+			logger.info(`App is running at http://localhost:%d in %s mode`, app.get('port'), app.get('env'));
 			logger.info('Press CTRL-C to stop\n');
 		});
-	}
-}).catch(err => logger.error(err));
+	})
+	.catch(err => {
+		logger.error('Could not start server!');
+		logger.error(err);
+	});

--- a/test/e2e/apply.test.ts
+++ b/test/e2e/apply.test.ts
@@ -59,7 +59,7 @@ const requestUser = {
 	authLevel: AuthLevel.Organiser
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 
 	mockRequestAuth = mock(RequestAuthentication);
@@ -92,17 +92,9 @@ beforeAll(async done => {
 		};
 	});
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
-
-			// After the application has been built and db connection established -- get the applicant repository
-			applicantRepository = container.get<ApplicantRepository>(TYPES.ApplicantRepository).getRepository();
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
+	// After the application has been built and db connection established -- get the applicant repository
+	applicantRepository = container.get<ApplicantRepository>(TYPES.ApplicantRepository).getRepository();
 });
 
 beforeEach(() => {

--- a/test/e2e/review.test.ts
+++ b/test/e2e/review.test.ts
@@ -47,7 +47,7 @@ const requestUser = {
 	authLevel: AuthLevel.Organiser
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 
 	mockRequestAuth = mock(RequestAuthentication);
@@ -83,17 +83,10 @@ beforeAll(async done => {
 	});
 	when(mockApplicantService.findOne(objectContaining({ id: '' }))).thenReturn(Promise.resolve(testApplicant));
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
 
-			// After the application has been built and db connection established -- get the applicant repository
-			reviewRepository = container.get<ReviewRepository>(TYPES.ReviewRepository).getRepository();
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
+	// After the application has been built and db connection established -- get the applicant repository
+	reviewRepository = container.get<ReviewRepository>(TYPES.ReviewRepository).getRepository();
 });
 
 beforeEach(() => {

--- a/test/integration/application/applicationController.test.ts
+++ b/test/integration/application/applicationController.test.ts
@@ -76,7 +76,7 @@ const getUniqueApplicant = (options?: { needsID: boolean }): [any, Applicant] =>
 	return [applicantRequest, applicant];
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 	mockCache = mock(Cache);
 	mockApplicantService = mock(ApplicantService);
@@ -112,14 +112,7 @@ beforeAll(async done => {
 		};
 	});
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
 });
 
 beforeEach(() => {

--- a/test/integration/application/applicationControllerClosed.test.ts
+++ b/test/integration/application/applicationControllerClosed.test.ts
@@ -74,7 +74,7 @@ const getUniqueApplicant = (): [any, Applicant] => {
 	return [applicantRequest, applicant];
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 	mockCache = mock(Cache);
 	mockApplicantService = mock(ApplicantService);
@@ -110,14 +110,7 @@ beforeAll(async done => {
 		};
 	});
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
 });
 
 beforeEach(() => {

--- a/test/integration/dashboard/dashboardController.test.ts
+++ b/test/integration/dashboard/dashboardController.test.ts
@@ -22,7 +22,7 @@ const requestUser = {
 	authLevel: AuthLevel.Organiser
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 	mockCache = mock(Cache);
 	mockRequestAuth = mock(RequestAuthentication);
@@ -56,14 +56,7 @@ beforeAll(async done => {
 		};
 	});
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
 });
 
 beforeEach(() => {

--- a/test/integration/review/reviewController.test.ts
+++ b/test/integration/review/reviewController.test.ts
@@ -38,7 +38,7 @@ const requestUser = {
 	authLevel: AuthLevel.Organiser
 };
 
-beforeAll(async done => {
+beforeAll(async () => {
 	initEnv();
 	mockRequestAuth = mock(RequestAuthentication);
 	mockSettingLoader = mock(SettingLoader);
@@ -77,14 +77,7 @@ beforeAll(async done => {
 		};
 	});
 
-	await new App().buildApp((builtApp: Express, err?: Error): void => {
-		if (err) {
-			done(`${err.message}\n${err.stack ?? ''}`);
-		} else {
-			bApp = builtApp;
-			done();
-		}
-	}, getTestDatabaseOptions());
+	bApp = await new App().buildApp(getTestDatabaseOptions());
 });
 
 beforeEach(() => {

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,4 +1,3 @@
-import { Express } from 'express';
 import { App } from '../../src/app';
 import { getConnection } from 'typeorm';
 import { getTestDatabaseOptions, initEnv } from '../util/testUtils';
@@ -13,61 +12,42 @@ beforeAll(() => {
 /**
  * Building app with default settings
  */
-test('App should build without errors', async done => {
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	await new App().buildApp(async (builtApp: Express, err: Error): Promise<void> => {
-		expect(err).toBe(undefined);
-		expect(builtApp.get('port')).toBe(process.env.PORT ?? 3000);
-		expect(builtApp.get('env')).toBe(process.env.ENVIRONMENT ?? 'production');
-		expect(getConnection('applications').isConnected).toBeTruthy();
-		await getConnection('applications').close();
-		done();
-	}, getTestDatabaseOptions());
+test('App should build without errors', async () => {
+	const builtApp = await new App().buildApp(getTestDatabaseOptions());
+	expect(builtApp.get('port')).toBe(process.env.PORT ?? 3000);
+	expect(builtApp.get('env')).toBe(process.env.ENVIRONMENT ?? 'production');
+	expect(getConnection('applications').isConnected).toBeTruthy();
+	await getConnection('applications').close();
 });
 
 /**
  * Testing dev environment
  */
-test('App should start in dev environment', async done => {
+test('App should start in dev environment', async () => {
 	process.env.ENVIRONMENT = 'dev';
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	await new App().buildApp(async (builtApp: Express, err: Error): Promise<void> => {
-		expect(builtApp.get('env')).toBe('dev');
-		expect(err).toBe(undefined);
-		expect(getConnection('applications').isConnected).toBeTruthy();
-		await getConnection('applications').close();
-		done();
-	}, getTestDatabaseOptions());
+	const builtApp = await new App().buildApp(getTestDatabaseOptions());
+	expect(builtApp.get('env')).toBe('dev');
+	expect(getConnection('applications').isConnected).toBeTruthy();
+	await getConnection('applications').close();
 });
 
 /**
  * Testing production environment
  */
-test('App should start in production environment', async done => {
+test('App should start in production environment', async () => {
 	process.env.ENVIRONMENT = 'production';
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	await new App().buildApp(async (builtApp: Express, err: Error): Promise<void> => {
-		expect(builtApp.get('env')).toBe('production');
-		expect(builtApp.get('trust proxy')).toBe(1);
-		expect(err).toBe(undefined);
-		expect(getConnection('applications').isConnected).toBeTruthy();
-		await getConnection('applications').close();
-		done();
-	}, getTestDatabaseOptions());
+	const builtApp = await new App().buildApp(getTestDatabaseOptions());
+	expect(builtApp.get('env')).toBe('production');
+	expect(builtApp.get('trust proxy')).toBe(1);
+	expect(getConnection('applications').isConnected).toBeTruthy();
+	await getConnection('applications').close();
 });
 
 /**
  * Testing error handling with incorrect settings
  */
-test('App should throw error with invalid settings', async done => {
+test('App should throw error with invalid settings', async () => {
 	process.env.DB_HOST = 'invalidhost';
-	await new App().buildApp(
-		// eslint-disable-next-line @typescript-eslint/no-misused-promises
-		async (builtApp: Express, err: Error): Promise<void> => {
-			expect(err).toBeTruthy();
-			expect(getConnection('applications').isConnected).toBeFalsy();
-			done();
-			return Promise.resolve();
-		}
-	);
+	await expect(new App().buildApp()).rejects.toThrow();
+	expect(getConnection('applications').isConnected).toBeFalsy();
 });


### PR DESCRIPTION
`App.buildApp(...)` currently uses a mixture of both callbacks and promises, which makes the code less readable. This PR refactors the method to only uses promises.

I've also added a small description to the README.