### PR TITLE
refactor: load environment variables into a config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,6 @@ DB_DATABASE=hs_application
 APPLICATION_URL=http://localhost:8010
 AUTH_URL=http://localhost:8000
 
-# Session Secret
-SESSION_SECRET=cat
-
 # Google Analytics GTAG ID
 GOOGLE_ANALYTICS_ID=example
 

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,6 @@ PORT=8010
 ENVIRONMENT=production
 
 # Database connection information
-DB_TYPE=mysql
-
 # When using in production, use the docker DB service name which is "mysql_db"
 # Otherwise, in dev, use "localhost"
 DB_HOST=mysql_db

--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,4 @@ GOOGLE_ANALYTICS_ID=example
 DROPBOX_API_TOKEN=example
 
 # Sendgrid API token
-SENDGRID_API_KEY=sendgrid_token
+SENDGRID_API_TOKEN=sendgrid_token

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-# Server set up information
+# Server config
 PORT=8010
-ENVIRONMENT=production
+ENVIRONMENT=dev
 
 # Database connection information
 # When using in production, use the docker DB service name which is "mysql_db"
 # Otherwise, in dev, use "localhost"
-DB_HOST=mysql_db
+DB_HOST=localhost
 DB_PORT=8011
 DB_USER=root
 DB_PASSWORD=root

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,6 @@ import dotenv from 'dotenv';
 import { Environment, getConfig } from './util/config';
 
 dotenv.config({ path: '.env' });
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 
 import path from 'path';
 import cookieParser from 'cookie-parser';

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,7 +28,7 @@ export class App {
 		// Set up express middleware for request routing
 		this.middlewareSetup(app);
 
-		if (app.get('env') === 'dev') {
+		if (app.get('env') === Environment.Dev) {
 			this.devMiddlewareSetup(app);
 		}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,9 @@
 import 'reflect-metadata';
 
 import dotenv from 'dotenv';
-import { Environment, getConfig } from './util/config';
-
 dotenv.config({ path: '.env' });
 
+import { Environment, getConfig } from './util/config';
 import path from 'path';
 import cookieParser from 'cookie-parser';
 import helmet from 'helmet';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,10 @@
 import 'reflect-metadata';
 
 import dotenv from 'dotenv';
-// Load environment variables from .env file
+import { Environment, getConfig } from './util/config';
+
 dotenv.config({ path: '.env' });
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 
 import path from 'path';
 import cookieParser from 'cookie-parser';
@@ -76,9 +78,9 @@ export class App {
 		app.set('view engine', 'ejs');
 
 		// Express configuration
-		app.set('port', process.env.PORT ?? 3000);
-		app.set('env', process.env.ENVIRONMENT ?? 'production');
-		if (process.env.ENVIRONMENT === 'production') {
+		app.set('port', getConfig().port);
+		app.set('env', getConfig().environment);
+		if (getConfig().environment === Environment.Production) {
 			app.set('trust proxy', 1);
 		}
 
@@ -91,7 +93,7 @@ export class App {
    */
 	private readonly middlewareSetup = (app: Express): void => {
 		app.use((req, res, next) => {
-			if (req.get('X-Forwarded-Proto') !== 'https' && process.env.USE_SSL) {
+			if (req.get('X-Forwarded-Proto') !== 'https' && getConfig().useSSL) {
 				res.redirect(`https://${req.headers.host ?? ''}${req.url}`);
 			} else {
 				return next();
@@ -129,11 +131,11 @@ export class App {
 		{
 			name: 'applications',
 			type: 'mysql',
-			host: process.env.DB_HOST,
-			port: Number(process.env.DB_PORT),
-			username: process.env.DB_USER,
-			password: process.env.DB_PASSWORD,
-			database: process.env.DB_DATABASE,
+			host: getConfig().db.host,
+			port: getConfig().db.port,
+			username: getConfig().db.user,
+			password: getConfig().db.password,
+			database: getConfig().db.database,
 			entities: [`${__dirname}/models/db/*{.js,.ts}`],
 			synchronize: true // Note: Unsafe in productionn, use migrations instead
 		}

--- a/src/services/cloudStorage/cloudStorageService.ts
+++ b/src/services/cloudStorage/cloudStorageService.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { injectable } from 'inversify';
 import { logger, getSafeUnicode } from '../../util';
 import { dropboxAPIFactory, DropboxMethods } from './dropboxAPIFactory';
+import { getConfig } from '../../util/config';
 
 export interface CloudStorageServiceInterface {
 	upload: (fileName: string, file: Buffer) => Promise<string>;
@@ -30,7 +31,7 @@ export class CloudStorageService {
 
 	public constructor() {
 		this.DROPBOX_BASE_PATH = 'hackathon-cv'; // TODO: Add ability to load from config file
-		this.DROPBOX_API_TOKEN = process.env.DROPBOX_API_TOKEN;
+		this.DROPBOX_API_TOKEN = getConfig().dropboxToken;
 
 		this.httpHeaderSafeJson = this.httpHeaderSafeJson.bind(this);
 	}

--- a/src/services/mail/emailService.ts
+++ b/src/services/mail/emailService.ts
@@ -3,6 +3,7 @@ import { Response } from 'request';
 import EmailTemplate from 'email-templates';
 import sgMail from '@sendgrid/mail';
 import { HttpResponseCode } from '../../util/errorHandling';
+import { getConfig } from '../../util/config';
 
 export interface EmailServiceInterface {
 	sendEmail: (from: string, recipient: string, subject: string, template: string, locals: any) => Promise<boolean>;
@@ -17,9 +18,8 @@ export class EmailService implements EmailServiceInterface {
 		template: string,
 		locals: any
 	): Promise<boolean> => {
-		if (!process.env.SENDGRID_API_KEY) { throw new Error('Failed to send email via Sendgrid, check sendgrid env settings'); }
-
-		sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+		if (!getConfig().sendgridToken) { throw new Error('Failed to send email via Sendgrid, check sendgrid env settings'); }
+		sgMail.setApiKey(getConfig().sendgridToken);
 
 		const msgOptions = {
 			from: from,

--- a/src/util/auth/hs_auth.ts
+++ b/src/util/auth/hs_auth.ts
@@ -6,7 +6,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../../types';
 import { Cache } from '../cache';
 import { getCurrentUser, User, AuthLevel } from '@unicsmcr/hs_auth_client';
-import { getConfig } from '../../util/config';
+import { getConfig, Environment } from '../../util/config';
 
 export interface RequestAuthenticationInterface {
 	passportSetup: (app: Express) => void;
@@ -22,7 +22,7 @@ export class RequestAuthentication {
 
 	private readonly logout = (app: Express): void => {
 		let logoutCookieOptions: CookieOptions;
-		if (app.get('env') === 'production') {
+		if (app.get('env') === Environment.Production) {
 			logoutCookieOptions = {
 				domain: app.locals.settings.rootDomain,
 				secure: true,

--- a/src/util/auth/hs_auth.ts
+++ b/src/util/auth/hs_auth.ts
@@ -6,6 +6,7 @@ import { injectable, inject } from 'inversify';
 import { TYPES } from '../../types';
 import { Cache } from '../cache';
 import { getCurrentUser, User, AuthLevel } from '@unicsmcr/hs_auth_client';
+import { getConfig } from '../../util/config';
 
 export interface RequestAuthenticationInterface {
 	passportSetup: (app: Express) => void;
@@ -93,9 +94,9 @@ export class RequestAuthentication {
 			// Either user was not authenticated, or an error occured during authentication
 			// In both cases we redirect them to the login
 			const queryParam: string = querystring.encode({
-				returnto: `${process.env.APPLICATION_URL ?? ''}${req.originalUrl}`
+				returnto: `${getConfig().hs.applicationUrl}${req.originalUrl}`
 			});
-			res.redirect(`${process.env.AUTH_URL ?? ''}/login?${queryParam}`);
+			res.redirect(`${getConfig().hs.authUrl}/login?${queryParam}`);
 			return;
 		}
 		res.locals.authLevel = user.authLevel;
@@ -104,8 +105,8 @@ export class RequestAuthentication {
 
 	public checkAuthLevel = (req: Request, res: Response, user: User|undefined, requiredAuth: AuthLevel): boolean => {
 		if (!user || user.authLevel < requiredAuth) {
-			const queryParam: string = querystring.encode({ returnto: `${process.env.APPLICATION_URL ?? ''}${req.originalUrl}` });
-			res.redirect(`${process.env.AUTH_URL ?? ''}/login?${queryParam}`);
+			const queryParam: string = querystring.encode({ returnto: `${getConfig().hs.applicationUrl}${req.originalUrl}` });
+			res.redirect(`${getConfig().hs.authUrl}/login?${queryParam}`);
 			return false;
 		}
 		return true;

--- a/src/util/config/config.ts
+++ b/src/util/config/config.ts
@@ -1,0 +1,58 @@
+import { getEnv, intoNumber } from './util';
+
+enum Environment {
+	Dev,
+	Production
+}
+
+interface EnvConfig {
+	port: number;
+	environment: Environment;
+	db: {
+		type: string;
+		host: string;
+		port: number;
+		user: string;
+		password: string;
+		database: string;
+	};
+	hs: {
+		applicationUrl: string;
+		authUrl: string;
+	};
+	sessionSecret: string;
+	googleAnalyticsId: string;
+	dropboxToken: string;
+	sendgridToken: string;
+}
+
+export function load(source: Record<string, string | undefined>): EnvConfig {
+	return {
+		port: intoNumber(getEnv(source, 'PORT')),
+		environment: getEnv(source, 'ENVIRONMENT') === 'dev' ? Environment.Dev : Environment.Production,
+		db: {
+			type: getEnv(source, 'DB_TYPE'),
+			host: getEnv(source, 'DB_HOST'),
+			port: intoNumber(getEnv(source, 'DB_PORT')),
+			user: getEnv(source, 'DB_USER'),
+			password: getEnv(source, 'DB_PASSWORD'),
+			database: getEnv(source, 'DB_DATABASE')
+		},
+		hs: {
+			applicationUrl: getEnv(source, 'APPLICATION_URL'),
+			authUrl: getEnv(source, 'AUTH_URL')
+		},
+		sessionSecret: getEnv(source, 'SESSION_SECRET'),
+		googleAnalyticsId: getEnv(source, 'GOOGLE_ANALYTICS_ID'),
+		dropboxToken: getEnv(source, 'DROPBOX_API_TOKEN'),
+		sendgridToken: getEnv(source, 'SENDGRID_API_KEY')
+	};
+}
+
+export function loadGlobal(source: Record<string, string | undefined>): EnvConfig {
+	globalConfig = load(source);
+	return globalConfig;
+}
+
+let globalConfig = load(process.env);
+export default globalConfig;

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -10,7 +10,6 @@ export interface EnvConfig {
 	environment: Environment;
 	useSSL: boolean;
 	db: {
-		type: string;
 		host: string;
 		port: number;
 		user: string;
@@ -37,7 +36,6 @@ export function load(source: Record<string, string | undefined> = process.env): 
 		environment: environment === 'dev' ? Environment.Dev : Environment.Production,
 		useSSL: intoBoolean(getEnv(source, 'USE_SSL')),
 		db: {
-			type: getEnv(source, 'DB_TYPE'),
 			host: getEnv(source, 'DB_HOST'),
 			port: intoNumber(getEnv(source, 'DB_PORT')),
 			user: getEnv(source, 'DB_USER'),

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -21,7 +21,6 @@ export interface EnvConfig {
 		applicationUrl: string;
 		authUrl: string;
 	};
-	sessionSecret: string;
 	googleAnalyticsId: string;
 	dropboxToken: string;
 	sendgridToken: string;
@@ -49,7 +48,6 @@ export function load(source: Record<string, string | undefined> = process.env): 
 			applicationUrl: getEnv(source, 'APPLICATION_URL'),
 			authUrl: getEnv(source, 'AUTH_URL')
 		},
-		sessionSecret: getEnv(source, 'SESSION_SECRET'),
 		googleAnalyticsId: getEnv(source, 'GOOGLE_ANALYTICS_ID'),
 		dropboxToken: getEnv(source, 'DROPBOX_API_TOKEN'),
 		sendgridToken: getEnv(source, 'SENDGRID_API_KEY')

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -48,7 +48,7 @@ export function load(source: Record<string, string | undefined> = process.env): 
 		},
 		googleAnalyticsId: getEnv(source, 'GOOGLE_ANALYTICS_ID'),
 		dropboxToken: getEnv(source, 'DROPBOX_API_TOKEN'),
-		sendgridToken: getEnv(source, 'SENDGRID_API_KEY')
+		sendgridToken: getEnv(source, 'SENDGRID_API_TOKEN')
 	};
 }
 

--- a/src/util/config/index.ts
+++ b/src/util/config/index.ts
@@ -5,7 +5,7 @@ export enum Environment {
 	Production = 'production'
 }
 
-interface EnvConfig {
+export interface EnvConfig {
 	port: number;
 	environment: Environment;
 	useSSL: boolean;
@@ -28,9 +28,14 @@ interface EnvConfig {
 }
 
 export function load(source: Record<string, string | undefined> = process.env): EnvConfig {
+	const environment = getEnv(source, 'ENVIRONMENT');
+	if (![Environment.Dev, Environment.Production].includes(environment as Environment)) {
+		throw new Error(`Invalid ENVIRONMENT variable, must be 'dev' or 'production'`);
+	}
+
 	return {
 		port: intoNumber(getEnv(source, 'PORT')),
-		environment: getEnv(source, 'ENVIRONMENT') === 'dev' ? Environment.Dev : Environment.Production,
+		environment: environment === 'dev' ? Environment.Dev : Environment.Production,
 		useSSL: intoBoolean(getEnv(source, 'USE_SSL')),
 		db: {
 			type: getEnv(source, 'DB_TYPE'),

--- a/src/util/config/util.ts
+++ b/src/util/config/util.ts
@@ -1,0 +1,18 @@
+export function getEnvOptional(source: Record<string, string | undefined>, name: string): string|undefined {
+	return source[name];
+}
+
+export function getEnvOrDefault(source: Record<string, string | undefined>, name: string, defaultValue: string) {
+	return getEnvOptional(source, name) ?? defaultValue;
+}
+
+export function getEnv(source: Record<string, string | undefined>, name: string) {
+	const value = getEnvOptional(source, name);
+	if (!value) throw new Error(`Property ${name} is missing from source.`);
+	return value;
+}
+
+export function intoNumber(str: string): number {
+	if (isNaN(Number(str))) throw new Error(`Value '${str}' is not a number.`);
+	return Number(str);
+}

--- a/src/util/config/util.ts
+++ b/src/util/config/util.ts
@@ -8,11 +8,20 @@ export function getEnvOrDefault(source: Record<string, string | undefined>, name
 
 export function getEnv(source: Record<string, string | undefined>, name: string) {
 	const value = getEnvOptional(source, name);
-	if (!value) throw new Error(`Property ${name} is missing from source.`);
+	if (typeof value === 'undefined') throw new Error(`Property ${name} is missing from source.`);
 	return value;
 }
 
 export function intoNumber(str: string): number {
 	if (isNaN(Number(str))) throw new Error(`Value '${str}' is not a number.`);
 	return Number(str);
+}
+
+export function intoBoolean(str: string): boolean {
+	if (str.toLowerCase() === 'false' || str === '0') {
+		return false;
+	} else if (str.toLowerCase() === 'true' || str === '1') {
+		return true;
+	}
+	throw new Error(`Value '${str}' is not a clear boolean value (should be true/false or 1/0)`);
 }

--- a/src/util/config/util.ts
+++ b/src/util/config/util.ts
@@ -13,7 +13,7 @@ export function getEnv(source: Record<string, string | undefined>, name: string)
 }
 
 export function intoNumber(str: string): number {
-	if (isNaN(Number(str))) throw new Error(`Value '${str}' is not a number.`);
+	if (!str.trim() || isNaN(Number(str))) throw new Error(`Value '${str}' is not a number.`);
 	return Number(str);
 }
 

--- a/src/util/errorHandling/errorHandler.ts
+++ b/src/util/errorHandling/errorHandler.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ApiError } from './apiError';
 import { HttpResponseCode } from './httpResponseCode';
 import { logger } from '../logger';
+import { getConfig, Environment } from '../../util/config';
 
 // const toEmails: string[] = ["admin@unicsmcr.com"];
 
@@ -10,7 +11,7 @@ import { logger } from '../logger';
  */
 export const errorHandler = (err: ApiError | Error, req: Request, res: Response): void => {
 	if (err instanceof Error) {
-		if (process.env.ENVIRONMENT === 'production') {
+		if (getConfig().environment === Environment.Production) {
 			// Send notification to admins when an uncaught error occurs
 			//   sendEmail("noreply@unicsmcr.com",
 			//   toEmails,

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -3,6 +3,7 @@ initEnv();
 
 import { getConnection } from 'typeorm';
 import { App } from '../../src/app';
+import { Environment } from '../../src/util/config';
 
 /**
  * Setup the env variables for the tests
@@ -27,10 +28,10 @@ test('App should build without errors', async () => {
  */
 test('App should start in dev environment', async () => {
 	updateEnv({
-		ENVIRONMENT: 'dev'
+		ENVIRONMENT: Environment.Dev
 	});
 	const builtApp = await new App().buildApp(getTestDatabaseOptions());
-	expect(builtApp.get('env')).toBe('dev');
+	expect(builtApp.get('env')).toBe(Environment.Dev);
 	expect(getConnection('applications').isConnected).toBeTruthy();
 	await getConnection('applications').close();
 });
@@ -40,10 +41,10 @@ test('App should start in dev environment', async () => {
  */
 test('App should start in production environment', async () => {
 	updateEnv({
-		ENVIRONMENT: 'production'
+		ENVIRONMENT: Environment.Production
 	});
 	const builtApp = await new App().buildApp(getTestDatabaseOptions());
-	expect(builtApp.get('env')).toBe('production');
+	expect(builtApp.get('env')).toBe(Environment.Production);
 	expect(builtApp.get('trust proxy')).toBe(1);
 	expect(getConnection('applications').isConnected).toBeTruthy();
 	await getConnection('applications').close();

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,6 +1,8 @@
-import { App } from '../../src/app';
+import { getTestDatabaseOptions, initEnv, updateEnv } from '../util/testUtils';
+initEnv();
+
 import { getConnection } from 'typeorm';
-import { getTestDatabaseOptions, initEnv } from '../util/testUtils';
+import { App } from '../../src/app';
 
 /**
  * Setup the env variables for the tests
@@ -14,7 +16,7 @@ beforeAll(() => {
  */
 test('App should build without errors', async () => {
 	const builtApp = await new App().buildApp(getTestDatabaseOptions());
-	expect(builtApp.get('port')).toBe(process.env.PORT ?? 3000);
+	expect(builtApp.get('port')).toBe(Number(process.env.PORT ?? 3000));
 	expect(builtApp.get('env')).toBe(process.env.ENVIRONMENT ?? 'production');
 	expect(getConnection('applications').isConnected).toBeTruthy();
 	await getConnection('applications').close();
@@ -24,7 +26,9 @@ test('App should build without errors', async () => {
  * Testing dev environment
  */
 test('App should start in dev environment', async () => {
-	process.env.ENVIRONMENT = 'dev';
+	updateEnv({
+		ENVIRONMENT: 'dev'
+	});
 	const builtApp = await new App().buildApp(getTestDatabaseOptions());
 	expect(builtApp.get('env')).toBe('dev');
 	expect(getConnection('applications').isConnected).toBeTruthy();
@@ -35,7 +39,9 @@ test('App should start in dev environment', async () => {
  * Testing production environment
  */
 test('App should start in production environment', async () => {
-	process.env.ENVIRONMENT = 'production';
+	updateEnv({
+		ENVIRONMENT: 'production'
+	});
 	const builtApp = await new App().buildApp(getTestDatabaseOptions());
 	expect(builtApp.get('env')).toBe('production');
 	expect(builtApp.get('trust proxy')).toBe(1);

--- a/test/unit/services/applicantService.test.ts
+++ b/test/unit/services/applicantService.test.ts
@@ -1,3 +1,6 @@
+import { initEnv } from '../../util';
+initEnv();
+
 import { when, mock, instance, verify, anything, objectContaining, reset, resetCalls } from 'ts-mockito';
 import container from '../../../src/inversify.config';
 import { TYPES } from '../../../src/types';

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -15,7 +15,6 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		DB_DATABASE: 'applications',
 		APPLICATION_URL: 'http://localhost:8080',
 		AUTH_URL: 'http://localhost:8001',
-		SESSION_SECRET: 'secret',
 		GOOGLE_ANALYTICS_ID: 'analyticsId',
 		DROPBOX_API_TOKEN: '',
 		SENDGRID_API_KEY: 'token'
@@ -36,7 +35,6 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 			applicationUrl: 'http://localhost:8080',
 			authUrl: 'http://localhost:8001'
 		},
-		sessionSecret: 'secret',
 		googleAnalyticsId: 'analyticsId',
 		dropboxToken: '',
 		sendgridToken: 'token'
@@ -57,7 +55,6 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		DB_DATABASE: 'applications',
 		APPLICATION_URL: 'http://localhost:8080',
 		AUTH_URL: 'http://localhost:8001',
-		SESSION_SECRET: '',
 		GOOGLE_ANALYTICS_ID: '',
 		DROPBOX_API_TOKEN: '',
 		SENDGRID_API_KEY: ''
@@ -78,7 +75,6 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 			applicationUrl: 'http://localhost:8080',
 			authUrl: 'http://localhost:8001'
 		},
-		sessionSecret: '',
 		googleAnalyticsId: '',
 		dropboxToken: '',
 		sendgridToken: ''

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/no-dynamic-delete */
+import { load, EnvConfig, Environment, getConfig } from '../../../../src/util/config';
+
+// Valid fixture
+const fixture1: [Record<string, string>, EnvConfig] = [
+	{
+		PORT: '8000',
+		ENVIRONMENT: 'dev',
+		USE_SSL: 'true',
+		DB_TYPE: 'mysql',
+		DB_HOST: 'localhost',
+		DB_PORT: '3306',
+		DB_USER: 'root',
+		DB_PASSWORD: 'password',
+		DB_DATABASE: 'applications',
+		APPLICATION_URL: 'http://localhost:8080',
+		AUTH_URL: 'http://localhost:8001',
+		SESSION_SECRET: 'secret',
+		GOOGLE_ANALYTICS_ID: 'analyticsId',
+		DROPBOX_API_TOKEN: '',
+		SENDGRID_API_KEY: 'token'
+	},
+	{
+		port: 8000,
+		environment: Environment.Dev,
+		useSSL: true,
+		db: {
+			type: 'mysql',
+			host: 'localhost',
+			user: 'root',
+			port: 3306,
+			password: 'password',
+			database: 'applications'
+		},
+		hs: {
+			applicationUrl: 'http://localhost:8080',
+			authUrl: 'http://localhost:8001'
+		},
+		sessionSecret: 'secret',
+		googleAnalyticsId: 'analyticsId',
+		dropboxToken: '',
+		sendgridToken: 'token'
+	}
+];
+
+// Valid fixture
+const fixture2: [Record<string, string>, EnvConfig] = [
+	{
+		PORT: '8000',
+		ENVIRONMENT: 'production',
+		USE_SSL: 'true',
+		DB_TYPE: 'mysql',
+		DB_HOST: 'localhost',
+		DB_PORT: '3306',
+		DB_USER: 'root',
+		DB_PASSWORD: 'password',
+		DB_DATABASE: 'applications',
+		APPLICATION_URL: 'http://localhost:8080',
+		AUTH_URL: 'http://localhost:8001',
+		SESSION_SECRET: '',
+		GOOGLE_ANALYTICS_ID: '',
+		DROPBOX_API_TOKEN: '',
+		SENDGRID_API_KEY: ''
+	},
+	{
+		port: 8000,
+		environment: Environment.Production,
+		useSSL: true,
+		db: {
+			type: 'mysql',
+			host: 'localhost',
+			user: 'root',
+			port: 3306,
+			password: 'password',
+			database: 'applications'
+		},
+		hs: {
+			applicationUrl: 'http://localhost:8080',
+			authUrl: 'http://localhost:8001'
+		},
+		sessionSecret: '',
+		googleAnalyticsId: '',
+		dropboxToken: '',
+		sendgridToken: ''
+	}
+];
+
+describe('load config', () => {
+	test('Valid env fixtures load correctly', () => {
+		expect(load(fixture1[0])).toEqual(fixture1[1]);
+		expect(load(fixture2[0])).toEqual(fixture2[1]);
+	});
+
+	test('Throws for missing values', () => {
+		for (const envKey of Object.keys(fixture1[0])) {
+			const fixture = { ...fixture1[0] };
+			delete fixture[envKey];
+			expect(() => load(fixture)).toThrow();
+		}
+
+		for (const envKey of Object.keys(fixture2[0])) {
+			const fixture = { ...fixture2[0] };
+			fixture[envKey] = undefined;
+			expect(() => load(fixture)).toThrow();
+		}
+	});
+
+	test('Environment types', () => {
+		expect(load(fixture1[0]).environment).toStrictEqual(Environment.Dev);
+		expect(load(fixture2[0]).environment).toStrictEqual(Environment.Production);
+		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toThrow();
+		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'prod' })).toThrow();
+		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toThrow();
+	});
+});
+
+
+describe('getConfig', () => {
+	test('Caching', () => {
+		let config = getConfig(fixture1[0]);
+		expect(config).toEqual(fixture1[1]);
+		expect(getConfig({ ...fixture1[0], PORT: '25565' })).toStrictEqual(config);
+		expect(getConfig({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toStrictEqual(config);
+		const oldConfig = { ...config };
+		config = getConfig({ ...fixture1[0], PORT: '25565', ENVIRONMENT: 'production' }, true);
+		expect(config).not.toEqual(oldConfig);
+		expect(getConfig({ ...fixture1[0], PORT: '25565' })).toStrictEqual(config);
+		expect(getConfig({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toStrictEqual(config);
+	});
+});

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -7,7 +7,6 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		PORT: '8000',
 		ENVIRONMENT: 'dev',
 		USE_SSL: 'true',
-		DB_TYPE: 'mysql',
 		DB_HOST: 'localhost',
 		DB_PORT: '3306',
 		DB_USER: 'root',
@@ -24,7 +23,6 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		environment: Environment.Dev,
 		useSSL: true,
 		db: {
-			type: 'mysql',
 			host: 'localhost',
 			user: 'root',
 			port: 3306,
@@ -47,7 +45,6 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		PORT: '8000',
 		ENVIRONMENT: 'production',
 		USE_SSL: 'true',
-		DB_TYPE: 'mysql',
 		DB_HOST: 'localhost',
 		DB_PORT: '3306',
 		DB_USER: 'root',
@@ -64,7 +61,6 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		environment: Environment.Production,
 		useSSL: true,
 		db: {
-			type: 'mysql',
 			host: 'localhost',
 			user: 'root',
 			port: 3306,

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -109,7 +109,7 @@ describe('load config', () => {
 		expect(load(fixture2[0]).environment).toStrictEqual(Environment.Production);
 		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toThrow();
 		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'prod' })).toThrow();
-		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'invalid' })).toThrow();
+		expect(() => load({ ...fixture1[0], ENVIRONMENT: 'development' })).toThrow();
 	});
 });
 

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -83,8 +83,11 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 
 describe('load config', () => {
 	test('Valid env fixtures load correctly', () => {
+		// Test it works when passing in the variables as a param
 		expect(load(fixture1[0])).toEqual(fixture1[1]);
-		expect(load(fixture2[0])).toEqual(fixture2[1]);
+		// Test it works with environment variables
+		Object.assign(process.env, fixture2[0]);
+		expect(load()).toEqual(fixture2[1]);
 	});
 
 	test('Throws for missing values', () => {

--- a/test/unit/util/config/config.test.ts
+++ b/test/unit/util/config/config.test.ts
@@ -16,7 +16,7 @@ const fixture1: [Record<string, string>, EnvConfig] = [
 		AUTH_URL: 'http://localhost:8001',
 		GOOGLE_ANALYTICS_ID: 'analyticsId',
 		DROPBOX_API_TOKEN: '',
-		SENDGRID_API_KEY: 'token'
+		SENDGRID_API_TOKEN: 'token'
 	},
 	{
 		port: 8000,
@@ -54,7 +54,7 @@ const fixture2: [Record<string, string>, EnvConfig] = [
 		AUTH_URL: 'http://localhost:8001',
 		GOOGLE_ANALYTICS_ID: '',
 		DROPBOX_API_TOKEN: '',
-		SENDGRID_API_KEY: ''
+		SENDGRID_API_TOKEN: ''
 	},
 	{
 		port: 8000,

--- a/test/unit/util/config/util.test.ts
+++ b/test/unit/util/config/util.test.ts
@@ -1,0 +1,89 @@
+import { getEnvOptional, getEnvOrDefault, getEnv, intoNumber, intoBoolean } from '../../../../src/util/config/util';
+
+describe('getEnvOptional', () => {
+	test('Defined inputs for getEnvOptional', () => {
+		expect(getEnvOptional({ val: '3' }, 'val')).toStrictEqual('3');
+		expect(getEnvOptional({ apple: '' }, 'apple')).toStrictEqual('');
+		expect(getEnvOptional({ banana: 'this is a string' }, 'banana')).toStrictEqual('this is a string');
+	});
+
+	test('Undefined inputs for getEnvOptional', () => {
+		expect(getEnvOptional({ val: '3' }, '3')).toBeUndefined();
+		expect(getEnvOptional({ apple: '' }, '')).toBeUndefined();
+		expect(getEnvOptional({ }, 'banana')).toBeUndefined();
+	});
+});
+
+describe('getEnvOrDefault', () => {
+	test('Defined inputs for getEnvOrDefault', () => {
+		expect(getEnvOrDefault({ val: '3' }, 'val', '4')).toStrictEqual('3');
+		expect(getEnvOrDefault({ apple: '' }, 'apple', 'string')).toStrictEqual('');
+		expect(getEnvOrDefault({ banana: 'this is a string' }, 'banana', 'orange')).toStrictEqual('this is a string');
+	});
+
+	test('Undefined inputs for getEnvOrDefault', () => {
+		expect(getEnvOrDefault({ val: '3' }, '3', 'defaultValue')).toStrictEqual('defaultValue');
+		expect(getEnvOrDefault({ apple: '' }, '', 'orange')).toStrictEqual('orange');
+		expect(getEnvOrDefault({ }, 'port', '25565')).toStrictEqual('25565');
+	});
+});
+
+describe('getEnv', () => {
+	test('Defined inputs for getEnv', () => {
+		expect(getEnvOptional({ val: '3' }, 'val')).toStrictEqual('3');
+		expect(getEnvOptional({ apple: '' }, 'apple')).toStrictEqual('');
+		expect(getEnvOptional({ banana: 'this is a string' }, 'banana')).toStrictEqual('this is a string');
+	});
+
+	test('Undefined inputs for getEnv should throw', () => {
+		expect(() => getEnv({ val: '3' }, '3')).toThrow();
+		expect(() => getEnv({ apple: '' }, 'banana')).toThrow();
+		expect(() => getEnv({ banana: 'this is a string' }, 'port')).toThrow();
+	});
+});
+
+describe('intoNumber', () => {
+	test('Valid inputs for intoNumber', () => {
+		expect(intoNumber('1')).toStrictEqual(1);
+		expect(intoNumber('1.0')).toStrictEqual(1);
+		expect(intoNumber('23')).toStrictEqual(23);
+		expect(intoNumber('0')).toStrictEqual(0);
+		expect(intoNumber('-32.3')).toStrictEqual(-32.3);
+		expect(intoNumber('42.6')).toStrictEqual(42.6);
+		expect(intoNumber('8080')).toStrictEqual(8080);
+	});
+
+	test('Inalid inputs for intoNumber', () => {
+		expect(() => intoNumber('a')).toThrow();
+		expect(() => intoNumber('')).toThrow();
+		expect(() => intoNumber(' ')).toThrow();
+		expect(() => intoNumber('one')).toThrow();
+		expect(() => intoNumber('.')).toThrow();
+		expect(() => intoNumber('false')).toThrow();
+	});
+});
+
+describe('intoBoolean', () => {
+	test('Valid inputs for intoBoolean', () => {
+		expect(intoBoolean('true')).toStrictEqual(true);
+		expect(intoBoolean('1')).toStrictEqual(true);
+		expect(intoBoolean('tRuE')).toStrictEqual(true);
+		expect(intoBoolean('TRUE')).toStrictEqual(true);
+
+		expect(intoBoolean('false')).toStrictEqual(false);
+		expect(intoBoolean('0')).toStrictEqual(false);
+		expect(intoBoolean('fAlSe')).toStrictEqual(false);
+		expect(intoBoolean('FALSE')).toStrictEqual(false);
+	});
+
+	test('Invalid inputs for intoBoolean', () => {
+		expect(() => intoBoolean('')).toThrow();
+		expect(() => intoBoolean('  ')).toThrow();
+		expect(() => intoBoolean('yes')).toThrow();
+		expect(() => intoBoolean('no')).toThrow();
+		expect(() => intoBoolean('1.0')).toThrow();
+		expect(() => intoBoolean('0.0')).toThrow();
+		expect(() => intoBoolean('tru')).toThrow();
+		expect(() => intoBoolean('fals')).toThrow();
+	});
+});

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -44,7 +44,6 @@ export function initEnv(): void {
 	process.env.ENVIRONMENT = Environment.Dev;
 	process.env.USE_SSL = 'false';
 
-	process.env.DB_TYPE = 'mysql';
 	process.env.DB_HOST = '';
 	process.env.DB_PORT = '3000';
 	process.env.DB_USER = '';

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { Connection, createConnections, getConnection, ConnectionOptions } from 'typeorm';
-import { getConfig } from '../../src/util/config';
+import { getConfig, Environment } from '../../src/util/config';
 
 export function getTestDatabaseOptions(entities?: (string | Function)[], name?: string): ConnectionOptions[] {
 	return [
@@ -41,7 +41,7 @@ export function updateEnv(props: Record<string, string>) {
 
 export function initEnv(): void {
 	process.env.PORT = '3000';
-	process.env.ENVIRONMENT = 'dev';
+	process.env.ENVIRONMENT = Environment.Dev;
 	process.env.USE_SSL = 'false';
 
 	process.env.DB_TYPE = 'mysql';

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { Connection, createConnections, getConnection, ConnectionOptions } from 'typeorm';
+import { getConfig } from '../../src/util/config';
 
 export function getTestDatabaseOptions(entities?: (string | Function)[], name?: string): ConnectionOptions[] {
 	return [
@@ -33,14 +34,29 @@ export async function reloadTestDatabaseConnection(name?: string): Promise<void>
 	await getConnection(name).synchronize(true);
 }
 
+export function updateEnv(props: Record<string, string>) {
+	Object.assign(process.env, props);
+	getConfig(process.env, true);
+}
+
 export function initEnv(): void {
-	process.env.SALT = 'random';
-	process.env.ITERATIONS = '30000';
-	process.env.KEY_LENGTH = '32';
-	process.env.DIGEST = 'sha256';
-	process.env.SESSION_SECRET = 'cat';
+	process.env.PORT = '3000';
 	process.env.ENVIRONMENT = 'dev';
+	process.env.USE_SSL = 'false';
+
+	process.env.DB_TYPE = 'mysql';
+	process.env.DB_HOST = '';
+	process.env.DB_PORT = '3000';
+	process.env.DB_USER = '';
+	process.env.DB_PASSWORD = '';
+	process.env.DB_DATABASE = '';
+
 	process.env.AUTH_URL = 'localhost:auth';
 	process.env.APPLICATION_URL = 'localhost:applications';
+
+	process.env.SESSION_SECRET = 'cat';
+	process.env.GOOGLE_ANALYTICS_ID = '';
 	process.env.DROPBOX_API_TOKEN = 'api_key';
+	process.env.SENDGRID_API_KEY = '';
+	getConfig(process.env, true);
 }

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -54,7 +54,6 @@ export function initEnv(): void {
 	process.env.AUTH_URL = 'localhost:auth';
 	process.env.APPLICATION_URL = 'localhost:applications';
 
-	process.env.SESSION_SECRET = 'cat';
 	process.env.GOOGLE_ANALYTICS_ID = '';
 	process.env.DROPBOX_API_TOKEN = 'api_key';
 	process.env.SENDGRID_API_KEY = '';

--- a/test/util/testUtils.ts
+++ b/test/util/testUtils.ts
@@ -55,6 +55,6 @@ export function initEnv(): void {
 
 	process.env.GOOGLE_ANALYTICS_ID = '';
 	process.env.DROPBOX_API_TOKEN = 'api_key';
-	process.env.SENDGRID_API_KEY = '';
+	process.env.SENDGRID_API_TOKEN = '';
 	getConfig(process.env, true);
 }


### PR DESCRIPTION
To make the code pass in strict mode, I hacked together a solution for fixing the environment variables being potentially undefined, leading to scenarios like this one:

```js
res.redirect(`${process.env.AUTH_URL ?? ''}/login?${queryParam}`);
```

This fixed the type errors but for obvious reasons isn't really any improvement. The bigger problem here is that you should really be told if you haven't set up environment variables properly for the project, this is something that has caught me out a few times and hopefully this PR addresses it!

A new `getConfig()` method is added, which loads all the environment variables needed by the project and tries to create a typed config for them. If any properties are missing or fail validation (e.g. if `PORT` Is non-numeric) then an error is thrown. This will prevent the app from even launching until the environment is correctly configured.

Previously, if you forgot to set `PORT` for example, the project would default to `3000` for you. The new behaviour would be that an error is thrown and that `PORT` must be set.

To-do:
- [x] write tests for new env config loader
- [x] update existing `.env.example`
- [x] review to find any unused variables
  - `SESSION_SECRET` did not appear to be used so I removed it
  - `DB_TYPE` was not used either. As we can only be sure the service works with a MySQL database, I removed the option to change this from the .env config.